### PR TITLE
Optimized quick plotting

### DIFF
--- a/nstbot/retinabot.py
+++ b/nstbot/retinabot.py
@@ -75,10 +75,17 @@ class RetinaBot(nstbot.NSTBot):
                                       args=(decay, display_mode))
             thread.daemon = True
             thread.start()
+            print thread
 
     def image_loop(self, decay, display_mode):
         import pylab
-        fig = pylab.figure()
+
+        import matplotlib.pyplot as plt
+        # using axis for updating only parts of the image that change
+        fig, ax = plt.subplots()
+        # so quick mode can run on ubuntu
+        plt.show(block=False)
+
         pylab.ion()
         img = pylab.imshow(self.image, vmax=1, vmin=-1,
                                        interpolation='none', cmap='binary')
@@ -116,11 +123,14 @@ class RetinaBot(nstbot.NSTBot):
 
             if display_mode == 'quick':
                 # this is much faster, but doesn't work on all systems
-                fig.canvas.draw()
+                ax.draw_artist(ax.patch)
+                ax.draw_artist(img)
+                fig.canvas.update()
+
                 fig.canvas.flush_events()
             else:
                 # this works on all systems, but is kinda slow
-                pylab.pause(0.001)
+                pylab.pause(1e-8)
 
             self.image *= decay
 

--- a/nstbot/retinabot.py
+++ b/nstbot/retinabot.py
@@ -123,7 +123,7 @@ class RetinaBot(nstbot.NSTBot):
 
             if display_mode == 'quick':
                 # this is faster, but doesn't work on all systems
-                fig.canvas_draw()
+                fig.canvas.draw()
                 fig.canvas.flush_events()
 
             elif display_mode == 'ubuntu_quick':

--- a/nstbot/retinabot.py
+++ b/nstbot/retinabot.py
@@ -75,7 +75,6 @@ class RetinaBot(nstbot.NSTBot):
                                       args=(decay, display_mode))
             thread.daemon = True
             thread.start()
-            print thread
 
     def image_loop(self, decay, display_mode):
         import pylab
@@ -110,6 +109,7 @@ class RetinaBot(nstbot.NSTBot):
             scatter = None
 
         while True:
+
             img.set_data(self.image)
 
             for k, rect in regions.items():
@@ -122,9 +122,15 @@ class RetinaBot(nstbot.NSTBot):
                 scatter.set_color(c)
 
             if display_mode == 'quick':
-                # this is much faster, but doesn't work on all systems
+                # this is faster, but doesn't work on all systems
+                fig.canvas_draw()
+                fig.canvas.flush_events()
+
+            elif display_mode == 'ubuntu_quick':
+                # this is even faster, but doesn't work on all systems
                 ax.draw_artist(ax.patch)
                 ax.draw_artist(img)
+                ax.draw_artist(scatter)
                 fig.canvas.update()
 
                 fig.canvas.flush_events()


### PR DESCRIPTION
- also added plt.show(block=False) command to have it work on Ubuntu

instead of redrawing the whole image only update those parts that have changed, based on code from http://bastibe.de/2013-05-30-speeding-up-matplotlib.html
